### PR TITLE
Add verbose and oneway diff

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -45,6 +45,20 @@ func Difference(slice1 []string, slice2 []string) []string {
 	return diff
 }
 
+func DifferenceOneWay(a, b []string) []string {
+	mb := make(map[string]struct{}, len(b))
+	for _, x := range b {
+		mb[x] = struct{}{}
+	}
+	var diff []string
+	for _, x := range a {
+		if _, found := mb[x]; !found {
+			diff = append(diff, x)
+		}
+	}
+	return diff
+}
+
 func GetSemverFromString(version string) (semver.Version, error) {
 	strippedVersion := strings.TrimPrefix(version, "v")
 	semVersion, err := semver.Make(strippedVersion)


### PR DESCRIPTION
* Verbose off by default, can be enabled using `--verbose`
* Add `--diff-oneway` to allow diffing one way, showing what is not in the first given version and what is in second given version